### PR TITLE
O  `TreeDumper.java`, para reconhecer qualquer production inicial

### DIFF
--- a/src/prolixa/TreeDumper.java
+++ b/src/prolixa/TreeDumper.java
@@ -52,7 +52,7 @@ public class TreeDumper extends DepthFirstAdapter {
 
         try {
             Start start = parser.parse();
-            start.getPExpr().apply(new TreeDumper(new PrintWriter(System.out)));
+            start.apply(new TreeDumper(new PrintWriter(System.out)));
         } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);


### PR DESCRIPTION
Antes o arquivo `TreeDumper.java` esperava que a primeira *production* fosse *exp*, agora aceita qualquer primeira *production*